### PR TITLE
Apply RTP timestamp patch - Fix RTP audio issues

### DIFF
--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -8907,6 +8907,7 @@ SWITCH_DECLARE(int) switch_rtp_write_frame(switch_rtp_t *rtp_session, switch_fra
 		data = frame->data;
 		len = frame->datalen;
 		ts = rtp_session->flags[SWITCH_RTP_FLAG_RAW_WRITE] ? (uint32_t) frame->timestamp : 0;
+		if (!ts) ts = rtp_session->last_write_ts + rtp_session->samples_per_interval;
 	}
 
 	/*


### PR DESCRIPTION
This reverts commit 47c5c8f.

Use the following for additional information.
https://github.com/briteback/freeswitch/commit/9f8968ccabb8a4e0353016d4ea0ff99561b005f1